### PR TITLE
Fix possible memory confusion in unsafe slice cast

### DIFF
--- a/conv.go
+++ b/conv.go
@@ -3,6 +3,7 @@ package gotils
 import (
 	"reflect"
 	"unsafe"
+	"runtime"
 )
 
 // B2S converts byte slice to a string without memory allocation.
@@ -11,14 +12,13 @@ import (
 // Note it may break if string and/or slice header will change
 // in the future go versions.
 func B2S(b []byte) string {
-	sh := (*reflect.StringHeader)(unsafe.Pointer(&b))
-	bh := reflect.SliceHeader{
-		Data: sh.Data,
-		Len:  sh.Len,
-		Cap:  sh.Len,
-	}
-
-	return *(*string)(unsafe.Pointer(&bh))
+	s := ""
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	sh.Data = bh.Data
+	sh.Len = bh.Len
+	runtime.KeepAlive(b)
+	return s
 }
 
 // S2B converts string to a byte slice without memory allocation.
@@ -26,12 +26,12 @@ func B2S(b []byte) string {
 // Note it may break if string and/or slice header will change
 // in the future go versions.
 func S2B(s string) []byte {
+	b := make([]byte, 0)
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := reflect.SliceHeader{
-		Data: sh.Data,
-		Len:  sh.Len,
-		Cap:  sh.Len,
-	}
-
-	return *(*[]byte)(unsafe.Pointer(&bh))
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	bh.Data = sh.Data
+	bh.Cap = sh.Len
+	bh.Len = sh.Len
+	runtime.KeepAlive(s)
+	return b
 }

--- a/conv.go
+++ b/conv.go
@@ -11,7 +11,7 @@ import (
 // Note it may break if string and/or slice header will change
 // in the future go versions.
 func B2S(b []byte) string {
-    return *(*string)(unsafe.Pointer(&b))
+	return *(*string)(unsafe.Pointer(&b))
 }
 
 // S2B converts string to a byte slice without memory allocation.

--- a/conv.go
+++ b/conv.go
@@ -24,6 +24,6 @@ func S2B(s string) (b []byte) {
 	bh.Data = sh.Data
 	bh.Cap = sh.Len
 	bh.Len = sh.Len
-	
+
 	return
 }

--- a/conv.go
+++ b/conv.go
@@ -2,8 +2,8 @@ package gotils
 
 import (
 	"reflect"
-	"unsafe"
 	"runtime"
+	"unsafe"
 )
 
 // B2S converts byte slice to a string without memory allocation.
@@ -17,7 +17,9 @@ func B2S(b []byte) string {
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	sh.Data = bh.Data
 	sh.Len = bh.Len
+	
 	runtime.KeepAlive(b)
+	
 	return s
 }
 
@@ -32,6 +34,8 @@ func S2B(s string) []byte {
 	bh.Data = sh.Data
 	bh.Cap = sh.Len
 	bh.Len = sh.Len
+	
 	runtime.KeepAlive(s)
+	
 	return b
 }

--- a/conv.go
+++ b/conv.go
@@ -24,5 +24,6 @@ func S2B(s string) (b []byte) {
 	bh.Data = sh.Data
 	bh.Cap = sh.Len
 	bh.Len = sh.Len
-	return b
+	
+	return
 }

--- a/conv.go
+++ b/conv.go
@@ -2,7 +2,6 @@ package gotils
 
 import (
 	"reflect"
-	"runtime"
 	"unsafe"
 )
 
@@ -12,30 +11,18 @@ import (
 // Note it may break if string and/or slice header will change
 // in the future go versions.
 func B2S(b []byte) string {
-	s := ""
-	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	sh.Data = bh.Data
-	sh.Len = bh.Len
-	
-	runtime.KeepAlive(b)
-	
-	return s
+    return *(*string)(unsafe.Pointer(&b))
 }
 
 // S2B converts string to a byte slice without memory allocation.
 //
 // Note it may break if string and/or slice header will change
 // in the future go versions.
-func S2B(s string) []byte {
-	b := make([]byte, 0)
+func S2B(s string) (b []byte) {
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 	bh.Data = sh.Data
 	bh.Cap = sh.Len
 	bh.Len = sh.Len
-	
-	runtime.KeepAlive(s)
-	
 	return b
 }


### PR DESCRIPTION
I found incorrect casts from `string` to `[]byte` and vice versa in `conv.go`. The problem is that when `reflect.SliceHeader` is created as a composite literal (instead of deriving it from an actual slice by cast), then the Go garbage collector will not treat its `Data` field as a reference. If the GC runs just between creating the `SliceHeader` and casting it into the final, real `[]byte` slice, then the underlying data might have been collected already, effectively making the returned `[]byte` slice a dangling pointer.

This has a low probability to occur, but projects that import this library might still use it in a code path that gets executed a lot, thus increasing the probability to happen. Depending on the memory layout at the time of the GC run, this could potentially create an information leak vulnerability.

This PR changes the function to create the `reflect.SliceHeader` from an actual slice by first instantiating the return value.

The `B2S` function was in fact even misusing the header types, as `reflect.StringHeader` was created from a slice and `reflect.SliceHeader` was cast into `string`. This actually kind of worked by accident only.